### PR TITLE
BAU: Stop looking for a Dockerfile. There is none.

### DIFF
--- a/build.jenkins
+++ b/build.jenkins
@@ -1,14 +1,10 @@
 pipeline {
-  agent {
-    docker {
-      image 'ruby:2.4'
-    }
-  }
+  agent none
   stages {
     stage('Build') {
       agent {
-        dockerfile {
-          additionalBuildArgs "--pull"
+        docker {
+          image 'ruby:2.4'
         }
       }
       steps {


### PR DESCRIPTION
There is no Dockerfile in this repository - we're just using the ruby image, so
there's no sense in using the 'dockerfile' agent.

Also, docker is only needed inside the stage, so move the agent settings there.

Solo: @rhowe-gds