### PR TITLE
BAU: Ensure we have fpm available to generate .deb packages

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,6 +9,9 @@ REVISION=${1:-1}
 rm -rf output
 mkdir -p output
 
+# TODO: Pin this with a separate bundler
+gem install fpm
+
 bundle package
 
 pushd output


### PR DESCRIPTION
Unsurprisingly, fpm isn't available in the ruby container. Install with 'gem'
for now, but the fpm packaging should be done in a separate jenkins stage using
a version of fpm pinned with bundler.

Solo: @rhowe-gds