### PR TITLE
Nonconflicting packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.swp
+/.bundle
+/buildtools
+/hiera-eyaml
 /output
-/vendor

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'hiera-eyaml'
-gem 'hiera-eyaml-gpg'
-gem 'ruby_gpg'

--- a/Gemfile.buildtools
+++ b/Gemfile.buildtools
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+# Gems needed to perform the build
+gem 'fpm'

--- a/Gemfile.buildtools.lock
+++ b/Gemfile.buildtools.lock
@@ -1,0 +1,47 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    arr-pm (0.0.10)
+      cabin (> 0)
+    backports (3.11.3)
+    cabin (0.9.0)
+    childprocess (0.9.0)
+      ffi (~> 1.0, >= 1.0.11)
+    clamp (1.0.1)
+    dotenv (2.4.0)
+    ffi (1.9.23)
+    fpm (1.9.3)
+      arr-pm (~> 0.0.10)
+      backports (>= 2.6.2)
+      cabin (>= 0.6.0)
+      childprocess
+      clamp (~> 1.0.0)
+      ffi
+      json (>= 1.7.7, < 2.0)
+      pleaserun (~> 0.0.29)
+      ruby-xz
+      stud
+    insist (1.0.0)
+    io-like (0.3.0)
+    json (1.8.6)
+    mustache (0.99.8)
+    pleaserun (0.0.30)
+      cabin (> 0)
+      clamp
+      dotenv
+      insist
+      mustache (= 0.99.8)
+      stud
+    ruby-xz (0.2.3)
+      ffi (~> 1.9)
+      io-like (~> 0.3)
+    stud (0.0.23)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  fpm
+
+BUNDLED WITH
+   1.16.1

--- a/Gemfile.hiera-eyaml
+++ b/Gemfile.hiera-eyaml
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+# Hiera-eyaml and its dependencies. These (and their dependencies) will be
+# packaged into .deb files.
+gem 'hiera-eyaml'
+gem 'hiera-eyaml-gpg'
+gem 'ruby_gpg'

--- a/Gemfile.hiera-eyaml.lock
+++ b/Gemfile.hiera-eyaml.lock
@@ -19,4 +19,4 @@ DEPENDENCIES
   ruby_gpg
 
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/README.md
+++ b/README.md
@@ -6,3 +6,17 @@ which include their own bundled Ruby in /opt/puppetlabs/puppet
 Usage: `./build.sh <version suffix>`
 
 Generated Debian packages will be placed in output/trusty/
+
+## How this works
+
+See `build.sh` for the details, but in summary:
+
+`Gemfile.hiera-eyaml` specifies the gems we want to package into .deb packages
+
+`Gemfile.buildtools` specifies gems we need in order to do that (at the time of
+writing, this is just `fpm`)
+
+`hiera-eyaml` and its dependencies are bundled into `hiera-eyaml` and the build
+tools are bundled into `buildtools`. We then use fpm to package all the
+`hiera-eyaml` gems into Debian packages with a custom gempath that matches the
+one for Puppetlabs' `puppet-agent` package and its bundled ruby.

--- a/README.md
+++ b/README.md
@@ -20,3 +20,8 @@ writing, this is just `fpm`)
 tools are bundled into `buildtools`. We then use fpm to package all the
 `hiera-eyaml` gems into Debian packages with a custom gempath that matches the
 one for Puppetlabs' `puppet-agent` package and its bundled ruby.
+
+We also prefix the names of the generated .deb packages with `puppet5-rubygem-`
+so that they do not conflict with system packages (since they're installed into
+a different gempath, they cannot conflict or be used by the system ruby). This
+prefix applies to packages pulled in as dependencies as well.

--- a/build.sh
+++ b/build.sh
@@ -22,6 +22,7 @@ pushd output
 for GEM in ../hiera-eyaml/vendor/cache/*.gem; do
   BUNDLE_GEMFILE=../Gemfile.buildtools bundle exec fpm -s gem -t deb \
     --prefix /opt/puppetlabs/puppet/lib/ruby/gems/2.4.0 \
+    --gem-package-name-prefix puppet5-rubygem \
     --iteration "${REVISION}~trusty1" \
     --architecture all \
     --maintainer "ida-operations@digital.cabinet-office.gov.uk" \

--- a/build.sh
+++ b/build.sh
@@ -9,15 +9,18 @@ REVISION=${1:-1}
 rm -rf output
 mkdir -p output
 
-# TODO: Pin this with a separate bundler
-gem install fpm
+command -v bundle > /dev/null || gem install bundler
 
-bundle package
+# Download & build hiera-eyaml gems
+bundle package --gemfile Gemfile.hiera-eyaml --path hiera-eyaml
+
+# Install tools needed to perform the packaging
+bundle install --gemfile Gemfile.buildtools --path buildtools
 
 pushd output
 
-for GEM in ../vendor/cache/*.gem; do
-  fpm -s gem -t deb \
+for GEM in ../hiera-eyaml/vendor/cache/*.gem; do
+  BUNDLE_GEMFILE=../Gemfile.buildtools bundle exec fpm -s gem -t deb \
     --prefix /opt/puppetlabs/puppet/lib/ruby/gems/2.4.0 \
     --iteration "${REVISION}~trusty1" \
     --architecture all \


### PR DESCRIPTION
This cleans up the build process somewhat, making lines of separation clear.

It also adds a prefix to the names of the generated .deb packages so that they cannot conflict with system packages.