### PR TITLE
Fix the artefact path for Debian packages

### DIFF
--- a/build.jenkins
+++ b/build.jenkins
@@ -21,7 +21,7 @@ pipeline {
         }
       }
       environment {
-        ARTEFACT_PATH='artefacts'
+        ARTEFACT_PATH='output/trusty'
         REPO_NAMES='main'
         REPO_PREFIX='.'
         REPO_DISTRIBUTION='main'


### PR DESCRIPTION
The aptly push was looking in the wrong place for generated packages. Look in
the right place.

C-c C-v error.