### PR TITLE
BAU: Support Puppet 6.0.3

### DIFF
--- a/Gemfile.hiera-eyaml
+++ b/Gemfile.hiera-eyaml
@@ -2,6 +2,5 @@ source 'https://rubygems.org'
 
 # Hiera-eyaml and its dependencies. These (and their dependencies) will be
 # packaged into .deb files.
-gem 'hiera-eyaml'
 gem 'hiera-eyaml-gpg'
 gem 'ruby_gpg'

--- a/Gemfile.hiera-eyaml.lock
+++ b/Gemfile.hiera-eyaml.lock
@@ -14,9 +14,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  hiera-eyaml
   hiera-eyaml-gpg
   ruby_gpg
 
 BUNDLED WITH
-   1.16.1
+   1.16.6

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ tools are bundled into `buildtools`. We then use fpm to package all the
 `hiera-eyaml` gems into Debian packages with a custom gempath that matches the
 one for Puppetlabs' `puppet-agent` package and its bundled ruby.
 
-We also prefix the names of the generated .deb packages with `puppet5-rubygem-`
+We also prefix the names of the generated .deb packages with `puppet6-rubygem-`
 so that they do not conflict with system packages (since they're installed into
 a different gempath, they cannot conflict or be used by the system ruby). This
 prefix applies to packages pulled in as dependencies as well.

--- a/build.sh
+++ b/build.sh
@@ -19,11 +19,16 @@ bundle install --gemfile Gemfile.buildtools --path buildtools
 
 pushd output
 
-for GEM in ../hiera-eyaml/vendor/cache/*.gem; do
+# We only actually want to package hiera-eyaml-gpg and ruby_gpg - everything
+# else is bundled with puppet-agent as of v6.0.3
+for GEM in ../hiera-eyaml/vendor/cache/hiera-eyaml-gpg-*.gem ../hiera-eyaml/vendor/cache/ruby_gpg-*.gem; do
   BUNDLE_GEMFILE=../Gemfile.buildtools bundle exec fpm -s gem -t deb \
     --prefix /opt/puppetlabs/puppet/lib/ruby/gems/2.5.0 \
     --gem-bin-path /opt/puppetlabs/puppet/bin \
     --gem-package-name-prefix puppet6-rubygem \
+    --gem-disable-dependency hiera-eyaml \
+    --gem-disable-dependency highline \
+    --gem-disable-dependency trollop \
     --iteration "${REVISION}~trusty1" \
     --architecture all \
     --maintainer "ida-operations@digital.cabinet-office.gov.uk" \


### PR DESCRIPTION
Puppet 6.0.3 bundles hiera-eyaml, highline and trollop so we don't need to
package those any more and in fact we need to exclude them from our package
dependencies or strange things will occur.

We only need to package hiera-eyaml-gpg and a GPG implementation.